### PR TITLE
模擬案件_#13_FeedPage, MyPage, FollowPageのerrorView表示バグ

### DIFF
--- a/Qiita_App/Qiita_App/Feed/FeedPageViewController.swift
+++ b/Qiita_App/Qiita_App/Feed/FeedPageViewController.swift
@@ -38,7 +38,7 @@ class FeedPageViewController: UIViewController {
         CommonApi().feedPageRequest(completion: { data in
             self.articleManagement()
             if data.isEmpty {
-                self.presentNetworkErrorView()
+                self.checkNetwork()
             }
             data.forEach {
                 self.articles.append($0)
@@ -69,7 +69,8 @@ class FeedPageViewController: UIViewController {
     }
     
     func checkNetwork() {
-        if let isConnected = NetworkReachabilityManager()?.isReachable, !isConnected {
+        guard let isConnected = NetworkReachabilityManager()?.isReachable else { return }
+        if !isConnected {
             presentNetworkErrorView()
             return
         }
@@ -82,11 +83,12 @@ class FeedPageViewController: UIViewController {
 
     @objc func handleRefreshControl() {
         page = 1
+        checkNetwork()
         
         CommonApi().feedPageRequest(completion: { data in
             self.articles.removeAll()
             if data.isEmpty {
-                self.presentNetworkErrorView()
+                self.checkNetwork()
             }
             data.forEach {
                 self.articles.append($0)
@@ -117,13 +119,13 @@ extension FeedPageViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
         //-10:基本的にはcountパラメータで20個の記事を取得してくるように指定しているので、20-10=10の10個目のセル、つまり最初に表示された半分までスクロールされたら、追加で記事を読み込む(ページネーション)するようになっています。
         if articles.count >= 20 && indexPath.row == ( articles.count - 10) {
-            checkNetwork()
             page += 1
+            checkNetwork()
             
             CommonApi().feedPageRequest(completion: { data in
                 self.articleManagement()
                 if data.isEmpty {
-                    self.presentNetworkErrorView()
+                    self.checkNetwork()
                 }
                 data.forEach {
                     self.articles.append($0)
@@ -161,7 +163,7 @@ extension FeedPageViewController: UISearchBarDelegate {
         CommonApi().feedPageRequest(completion: { data in
             self.articleManagement()
             if data.isEmpty {
-                self.presentNetworkErrorView()
+                self.checkNetwork()
             }
             data.forEach {
                 self.articles.append($0)

--- a/Qiita_App/Qiita_App/Follow/FollowPageViewController.swift
+++ b/Qiita_App/Qiita_App/Follow/FollowPageViewController.swift
@@ -56,7 +56,7 @@ class FollowPageViewController: UIViewController {
         
         CommonApi.followPageRequest(completion: { data in
             if data.isEmpty {
-                self.presentNetworkErrorView()
+                self.checkNetwork()
             }
             data.forEach {
                 self.userInfos.append($0)
@@ -78,7 +78,7 @@ class FollowPageViewController: UIViewController {
         
         CommonApi.followPageRequest(completion: { data in
             if data.isEmpty {
-                self.presentNetworkErrorView()
+                self.checkNetwork()
             }
             data.forEach {
                 self.userInfos.append($0)
@@ -104,7 +104,7 @@ class FollowPageViewController: UIViewController {
         CommonApi.followPageRequest(completion: { data in
             self.userInfos.removeAll()
             if data.isEmpty {
-                self.presentNetworkErrorView()
+                self.checkNetwork()
             }
             data.forEach {
                 self.userInfos.append($0)
@@ -137,6 +137,9 @@ extension FollowPageViewController: UITableViewDataSource {
             checkNetwork()
             
             CommonApi.followPageRequest(completion: { data in
+                if data.isEmpty {
+                    self.checkNetwork()
+                }
                 data.forEach {
                     self.userInfos.append($0)
                 }

--- a/Qiita_App/Qiita_App/MyPage/MyPageViewController.swift
+++ b/Qiita_App/Qiita_App/MyPage/MyPageViewController.swift
@@ -43,7 +43,7 @@ class MyPageViewController: UIViewController {
         
         CommonApi().myPageRequest(completion: { data in
             if data.isEmpty {
-                self.presentNetworkErrorView()
+                self.checkNetwork()
             }
             data.forEach {
                 self.myArticles.append($0)
@@ -113,7 +113,7 @@ class MyPageViewController: UIViewController {
         CommonApi().myPageRequest(completion: { data in
             self.myArticles.removeAll()
             if data.isEmpty {
-                self.presentNetworkErrorView()
+                self.checkNetwork()
             }
             data.forEach {
                 self.myArticles.append($0)
@@ -166,6 +166,9 @@ extension MyPageViewController: UITableViewDataSource {
             page += 1
             
             CommonApi().myPageRequest(completion: { data in
+                if data.isEmpty {
+                    self.checkNetwork()
+                }
                 data.forEach {
                     self.myArticles.append($0)
                 }
@@ -193,7 +196,7 @@ extension MyPageViewController: ReloadActionDelegate {
             CommonApi().myPageRequest(completion: { data in
                 self.myArticles.removeAll()
                 if data.isEmpty {
-                    self.presentNetworkErrorView()
+                    self.checkNetwork()
                 }
                 data.forEach {
                     self.myArticles.append($0)


### PR DESCRIPTION
- issue:[#13](https://github.com/shinonome-inc/mobile_sakai/issues/45)
- 確認してほしい点
FeedPage：検索結果が何も見つからなかった場合
MyPage：未ログイン時
FollowPage：フォローもしくはフォロワーが0のユーザーのFollowPageを表示した場合
以上の時にネットワークにつながっていてもerrorViewが表示されてしまわないかを確認していただきたいです。