### PR TITLE
模擬案件_#15_CellのIdentifierを変数で管理

### DIFF
--- a/Qiita_App/Qiita_App.xcodeproj/project.pbxproj
+++ b/Qiita_App/Qiita_App.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		372618CB28352E9673FAD014 /* Pods_Qiita_App_Qiita_AppUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E51BF7201AE226CA5FA6EA2A /* Pods_Qiita_App_Qiita_AppUITests.framework */; };
 		8951C901D3280165AAA67226 /* Pods_Qiita_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D267A09C6D8BB6602C0AC844 /* Pods_Qiita_App.framework */; };
 		D52A24D5AF241FD14F048CBD /* Pods_Qiita_AppTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFAF87A7378337E9C6265B64 /* Pods_Qiita_AppTests.framework */; };
+		F195A01727BD00500092A684 /* SettingCellidentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F195A01627BD00500092A684 /* SettingCellidentifier.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -123,6 +124,7 @@
 		D267A09C6D8BB6602C0AC844 /* Pods_Qiita_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Qiita_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E51BF7201AE226CA5FA6EA2A /* Pods_Qiita_App_Qiita_AppUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Qiita_App_Qiita_AppUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB58EEE744CB75716F5B4C0B /* Pods-Qiita_App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Qiita_App.release.xcconfig"; path = "Target Support Files/Pods-Qiita_App/Pods-Qiita_App.release.xcconfig"; sourceTree = "<group>"; };
+		F195A01627BD00500092A684 /* SettingCellidentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCellidentifier.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -306,6 +308,7 @@
 				07EBA54227741675009C6765 /* MainTabBarController.swift */,
 				07EBA54327741675009C6765 /* CommonApi.swift */,
 				07EBA54427741675009C6765 /* SecretKey.swift */,
+				F195A01627BD00500092A684 /* SettingCellidentifier.swift */,
 			);
 			path = Other;
 			sourceTree = "<group>";
@@ -607,6 +610,7 @@
 				07EBA51D277415F0009C6765 /* TagListCell.swift in Sources */,
 				07EBA51C277415F0009C6765 /* TagDetailCell.swift in Sources */,
 				07FD0AB727A24AF50032C7BE /* UserPageCell.swift in Sources */,
+				F195A01727BD00500092A684 /* SettingCellidentifier.swift in Sources */,
 				07EBA54827741675009C6765 /* ApiModel.swift in Sources */,
 				07EBA5372774166E009C6765 /* NotLoginPageViewController.swift in Sources */,
 				07EBA514277415CE009C6765 /* FeedPageCell.swift in Sources */,

--- a/Qiita_App/Qiita_App.xcodeproj/project.pbxproj
+++ b/Qiita_App/Qiita_App.xcodeproj/project.pbxproj
@@ -49,7 +49,7 @@
 		372618CB28352E9673FAD014 /* Pods_Qiita_App_Qiita_AppUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E51BF7201AE226CA5FA6EA2A /* Pods_Qiita_App_Qiita_AppUITests.framework */; };
 		8951C901D3280165AAA67226 /* Pods_Qiita_App.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D267A09C6D8BB6602C0AC844 /* Pods_Qiita_App.framework */; };
 		D52A24D5AF241FD14F048CBD /* Pods_Qiita_AppTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BFAF87A7378337E9C6265B64 /* Pods_Qiita_AppTests.framework */; };
-		F195A01727BD00500092A684 /* SettingCellidentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F195A01627BD00500092A684 /* SettingCellidentifier.swift */; };
+		F195A01727BD00500092A684 /* IdentifierOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = F195A01627BD00500092A684 /* IdentifierOption.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -124,7 +124,7 @@
 		D267A09C6D8BB6602C0AC844 /* Pods_Qiita_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Qiita_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E51BF7201AE226CA5FA6EA2A /* Pods_Qiita_App_Qiita_AppUITests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Qiita_App_Qiita_AppUITests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		EB58EEE744CB75716F5B4C0B /* Pods-Qiita_App.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Qiita_App.release.xcconfig"; path = "Target Support Files/Pods-Qiita_App/Pods-Qiita_App.release.xcconfig"; sourceTree = "<group>"; };
-		F195A01627BD00500092A684 /* SettingCellidentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingCellidentifier.swift; sourceTree = "<group>"; };
+		F195A01627BD00500092A684 /* IdentifierOption.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifierOption.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -308,7 +308,7 @@
 				07EBA54227741675009C6765 /* MainTabBarController.swift */,
 				07EBA54327741675009C6765 /* CommonApi.swift */,
 				07EBA54427741675009C6765 /* SecretKey.swift */,
-				F195A01627BD00500092A684 /* SettingCellidentifier.swift */,
+				F195A01627BD00500092A684 /* IdentifierOption.swift */,
 			);
 			path = Other;
 			sourceTree = "<group>";
@@ -610,7 +610,7 @@
 				07EBA51D277415F0009C6765 /* TagListCell.swift in Sources */,
 				07EBA51C277415F0009C6765 /* TagDetailCell.swift in Sources */,
 				07FD0AB727A24AF50032C7BE /* UserPageCell.swift in Sources */,
-				F195A01727BD00500092A684 /* SettingCellidentifier.swift in Sources */,
+				F195A01727BD00500092A684 /* IdentifierOption.swift in Sources */,
 				07EBA54827741675009C6765 /* ApiModel.swift in Sources */,
 				07EBA5372774166E009C6765 /* NotLoginPageViewController.swift in Sources */,
 				07EBA514277415CE009C6765 /* FeedPageCell.swift in Sources */,

--- a/Qiita_App/Qiita_App/Feed/FeedPageViewController.swift
+++ b/Qiita_App/Qiita_App/Feed/FeedPageViewController.swift
@@ -109,7 +109,8 @@ extension FeedPageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "ArticleCell", for: indexPath) as? FeedPageCellViewController else {
+        let identifier = SettingCellidentifier.cellType.feedPage.identifier
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as? FeedPageCellViewController else {
             return UITableViewCell()
         }
         cell.setArticleCell(data: articles[indexPath.row])

--- a/Qiita_App/Qiita_App/Feed/FeedPageViewController.swift
+++ b/Qiita_App/Qiita_App/Feed/FeedPageViewController.swift
@@ -109,7 +109,7 @@ extension FeedPageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let identifier = SettingCellidentifier.cellType.feedPage.identifier
+        let identifier = IdentifierOption.cellType.feedPage.identifier
         guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as? FeedPageCellViewController else {
             return UITableViewCell()
         }

--- a/Qiita_App/Qiita_App/Follow/FollowPageViewController.swift
+++ b/Qiita_App/Qiita_App/Follow/FollowPageViewController.swift
@@ -124,7 +124,7 @@ extension FollowPageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let identifier = SettingCellidentifier.cellType.followPage.identifier
+        let identifier = IdentifierOption.cellType.followPage.identifier
         guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as? FollowPageCellViewController else {
             return UITableViewCell()
         }

--- a/Qiita_App/Qiita_App/Follow/FollowPageViewController.swift
+++ b/Qiita_App/Qiita_App/Follow/FollowPageViewController.swift
@@ -124,7 +124,8 @@ extension FollowPageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "UserCell", for: indexPath) as? FollowPageCellViewController else {
+        let identifier = SettingCellidentifier.cellType.followPage.identifier
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as? FollowPageCellViewController else {
             return UITableViewCell()
         }
         cell.setArticleCell(data: userInfos[indexPath.row])

--- a/Qiita_App/Qiita_App/MyPage/MyPageViewController.swift
+++ b/Qiita_App/Qiita_App/MyPage/MyPageViewController.swift
@@ -152,7 +152,8 @@ extension MyPageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "MyArticleCell", for: indexPath) as? MyPageCellViewController else {
+        let identifier = SettingCellidentifier.cellType.myPage.identifier
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as? MyPageCellViewController else {
             return UITableViewCell()
         }
         cell.setMyArticleCell(data: myArticles[indexPath.row])

--- a/Qiita_App/Qiita_App/MyPage/MyPageViewController.swift
+++ b/Qiita_App/Qiita_App/MyPage/MyPageViewController.swift
@@ -152,7 +152,7 @@ extension MyPageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let identifier = SettingCellidentifier.cellType.myPage.identifier
+        let identifier = IdentifierOption.cellType.myPage.identifier
         guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as? MyPageCellViewController else {
             return UITableViewCell()
         }

--- a/Qiita_App/Qiita_App/Other/IdentifierOption.swift
+++ b/Qiita_App/Qiita_App/Other/IdentifierOption.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class SettingCellidentifier {
+class IdentifierOption {
     
     enum cellType {
         case feedPage

--- a/Qiita_App/Qiita_App/Other/SettingCellidentifier.swift
+++ b/Qiita_App/Qiita_App/Other/SettingCellidentifier.swift
@@ -1,0 +1,38 @@
+//
+//  SettingCellidentifier.swift
+//  Qiita_App
+//
+//  Created by 堺俊也 on 2022/02/16.
+//  Copyright © 2022 Sakai Syunya. All rights reserved.
+//
+
+import UIKit
+
+class SettingCellidentifier {
+    
+    enum cellType {
+        case feedPage
+        case tagPage
+        case tagDetailPage
+        case myPage
+        case userPage
+        case followPage
+        
+        var identifier: String {
+            switch self {
+            case .feedPage:
+                return "ArticleCell"
+            case .tagPage:
+                return "TagCell"
+            case .tagDetailPage:
+                return "ArticleCell"
+            case .myPage:
+                return "MyArticleCell"
+            case .userPage:
+                return "UserArticleCell"
+            case .followPage:
+                return "UserCell"
+            }
+        }
+    }
+}

--- a/Qiita_App/Qiita_App/Tag/TagDetailPageViewController.swift
+++ b/Qiita_App/Qiita_App/Tag/TagDetailPageViewController.swift
@@ -77,7 +77,7 @@ extension TagDetailPageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let identifier = SettingCellidentifier.cellType.tagDetailPage.identifier
+        let identifier = IdentifierOption.cellType.tagDetailPage.identifier
         guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as? TagDetailPageCellViewController else {
             return UITableViewCell()
         }

--- a/Qiita_App/Qiita_App/Tag/TagDetailPageViewController.swift
+++ b/Qiita_App/Qiita_App/Tag/TagDetailPageViewController.swift
@@ -77,7 +77,8 @@ extension TagDetailPageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "ArticleCell", for: indexPath) as? TagDetailPageCellViewController else {
+        let identifier = SettingCellidentifier.cellType.tagDetailPage.identifier
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as? TagDetailPageCellViewController else {
             return UITableViewCell()
         }
         cell.setTagDetailArticleCell(data: articles[indexPath.row])

--- a/Qiita_App/Qiita_App/Tag/TagListPageViewController.swift
+++ b/Qiita_App/Qiita_App/Tag/TagListPageViewController.swift
@@ -134,7 +134,8 @@ extension TagListPageViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "TagCell", for: indexPath) as? TagListCellViewController else {
+        let identifier = SettingCellidentifier.cellType.tagPage.identifier
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath) as? TagListCellViewController else {
             return UICollectionViewCell()
         }
         cell.setTagCell(data: tagInfo[indexPath.row])

--- a/Qiita_App/Qiita_App/Tag/TagListPageViewController.swift
+++ b/Qiita_App/Qiita_App/Tag/TagListPageViewController.swift
@@ -134,7 +134,7 @@ extension TagListPageViewController: UICollectionViewDataSource {
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-        let identifier = SettingCellidentifier.cellType.tagPage.identifier
+        let identifier = IdentifierOption.cellType.tagPage.identifier
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: identifier, for: indexPath) as? TagListCellViewController else {
             return UICollectionViewCell()
         }

--- a/Qiita_App/Qiita_App/User/UserPageViewController.swift
+++ b/Qiita_App/Qiita_App/User/UserPageViewController.swift
@@ -152,7 +152,8 @@ extension UserPageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: "UserArticleCell", for: indexPath) as? UserPageCellViewController else {
+        let identifier = SettingCellidentifier.cellType.userPage.identifier
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as? UserPageCellViewController else {
             return UITableViewCell()
         }
         cell.setUserArticleCell(data: userArticles[indexPath.row])

--- a/Qiita_App/Qiita_App/User/UserPageViewController.swift
+++ b/Qiita_App/Qiita_App/User/UserPageViewController.swift
@@ -152,7 +152,7 @@ extension UserPageViewController: UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let identifier = SettingCellidentifier.cellType.userPage.identifier
+        let identifier = IdentifierOption.cellType.userPage.identifier
         guard let cell = tableView.dequeueReusableCell(withIdentifier: identifier, for: indexPath) as? UserPageCellViewController else {
             return UITableViewCell()
         }


### PR DESCRIPTION
- issue:[#15](https://github.com/shinonome-inc/mobile_sakai/issues/53)
- 確認してほしい点
・新しく`SettingCellidentifier.swift`を追加したのでその部分のコードと、それぞれの画面のCellのidentifierを設定している部分のコードを見ていただきたいです。